### PR TITLE
View protocol now conforms to VIPER stack protocol

### DIFF
--- a/Viper.xctemplate/Default/___FILEBASENAME___ViewController.swift
+++ b/Viper.xctemplate/Default/___FILEBASENAME___ViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-protocol ___VARIABLE_MODULENAME___ViewProtocol: class {
+protocol ___VARIABLE_MODULENAME___ViewProtocol: ___VARIABLE_MODULENAME___Protocol {
     func setPresenter(_ presenter: ___VARIABLE_MODULENAME___PresenterProtocol)
 }
 

--- a/Viper.xctemplate/FileHeaderComments/___FILEBASENAME___ViewController.swift
+++ b/Viper.xctemplate/FileHeaderComments/___FILEBASENAME___ViewController.swift
@@ -11,7 +11,7 @@
 
 import UIKit
 
-protocol ___VARIABLE_MODULENAME___ViewProtocol: class {
+protocol ___VARIABLE_MODULENAME___ViewProtocol: ___VARIABLE_MODULENAME___Protocol {
     func setPresenter(_ presenter: ___VARIABLE_MODULENAME___PresenterProtocol)
 }
 


### PR DESCRIPTION
Hi,

the View protocol now conforms to the VIPER stack protocol. That way we don't need to cast the ViewController returned from the makeViewController method to the VIPER stack protocol. We can just update the VIPER stack from the outside ;)